### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/auto-merge-dockers.yml
+++ b/.github/workflows/auto-merge-dockers.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Post to a Slack channel
         if: ${{ failure() }}
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0  # disable-secrets-detection
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0  # disable-secrets-detection
         with:
           channel-id: 'auto-merge-docker-action'
           slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"

--- a/.github/workflows/autobump_rn.yml
+++ b/.github/workflows/autobump_rn.yml
@@ -20,16 +20,16 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install python dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/check-contribution-form-filled.yml
+++ b/.github/workflows/check-contribution-form-filled.yml
@@ -13,13 +13,13 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false && contains(github.event.pull_request.title, '[Marketplace Contribution]') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install Python Dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/check-contributor-pack.yml
+++ b/.github/workflows/check-contributor-pack.yml
@@ -13,13 +13,13 @@ jobs:
     if: github.repository == 'demisto/content' && startsWith(github.head_ref, 'contrib/') == false && startsWith(github.head_ref, 'to-merge/') == false && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.9"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install python dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/check-devcontainer.yml
+++ b/.github/workflows/check-devcontainer.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
     - name: Run demisto-sdk in devcontainer
-      uses: devcontainers/ci@v0.3  # disable-secrets-detection
+      uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3  # disable-secrets-detection
       with:    
         push: never
         runCmd: demisto-sdk --version

--- a/.github/workflows/check-partner-approved-label.yml
+++ b/.github/workflows/check-partner-approved-label.yml
@@ -12,13 +12,13 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install python dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/clean_stale_branches.yml
+++ b/.github/workflows/clean_stale_branches.yml
@@ -15,9 +15,9 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Stale
-        uses: actions/stale@v8
+        uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}
           days-before-issue-stale: -1

--- a/.github/workflows/close_jira_issue_by_pr_merge.yml
+++ b/.github/workflows/close_jira_issue_by_pr_merge.yml
@@ -12,14 +12,14 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && github.event.action == 'closed' && github.event.pull_request.merged == true && startsWith(github.head_ref, 'contrib/') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
-      - uses: actions/cache@v4
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/create-internal-pr-from-external.yml
+++ b/.github/workflows/create-internal-pr-from-external.yml
@@ -17,13 +17,13 @@ jobs:
         run: |
           echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Print Context
         run: |
           echo "$GITHUB_CONTEXT"

--- a/.github/workflows/handle-new-external-pr.yml
+++ b/.github/workflows/handle-new-external-pr.yml
@@ -12,16 +12,16 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.action == 'opened' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Print Context
         run: |
           echo "$GITHUB_CONTEXT"

--- a/.github/workflows/link_edited_pr_to_jira_issue.yml
+++ b/.github/workflows/link_edited_pr_to_jira_issue.yml
@@ -12,14 +12,14 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && startsWith(github.head_ref, 'contrib/') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
-      - uses: actions/cache@v4
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
           path: .venv
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/pre-commit-reuse.yml
+++ b/.github/workflows/pre-commit-reuse.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write
     steps:
     - name: Install poetry
-      uses: Gr1N/setup-poetry@v9
+      uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
       run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
 
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
       with:
         python-version: '3.10'
         cache: 'poetry'

--- a/.github/workflows/project_manager_daily.yml
+++ b/.github/workflows/project_manager_daily.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'demisto/content'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Python 3.7
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.7"
       - name: Get project manager

--- a/.github/workflows/project_manager_hourly.yml
+++ b/.github/workflows/project_manager_hourly.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'demisto/content'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Python 3.7
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.7"
       - name: Get project manager

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 100 # to speed up. changed-files will fetch more if necessary
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.x"
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1 # disable-secrets-detection
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1 # disable-secrets-detection
         with:
           files: |
             .gitlab/ci/.gitlab-ci.yml

--- a/.github/workflows/protect-infra-directories-contributions.yml
+++ b/.github/workflows/protect-infra-directories-contributions.yml
@@ -12,16 +12,16 @@ jobs:
     if: 'startsWith(github.head_ref, ''contrib'') || (github.event.pull_request.head.repo.fork == true && contains(github.event.pull_request.base.ref, ''contrib''))'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.x'
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1  # disable-secrets-detection
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1  # disable-secrets-detection
 
       - name: Check for changes in protected directories
         run: |

--- a/.github/workflows/purge_branch_protection_rules.yml
+++ b/.github/workflows/purge_branch_protection_rules.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.7  # disable-secrets-detection
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7  # disable-secrets-detection
 
       - name: Set up Python
-        uses: actions/setup-python@v5.1.1  # disable-secrets-detection
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1  # disable-secrets-detection
         with:
           python-version: '3.10'
 
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
 
       - name: Install python dependencies
         run: |
@@ -38,7 +38,7 @@ jobs:
           poetry run python .github/github_workflow_scripts/purge_branch_protection_rules.py
           
       - name: Upload Log to Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
           name: purge_branch_protection_rules_${{ github.run_id }}
           path: "${{ github.workspace }}/purge_branch_protection_rules.log"

--- a/.github/workflows/review-release-notes.yml
+++ b/.github/workflows/review-release-notes.yml
@@ -10,12 +10,12 @@ jobs:
     if: github.repository == 'demisto/content'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1 # disable-secrets-detection
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1 # disable-secrets-detection
         with:
           separator: ${{ env.CHANGED_FILES_DELIMITER }}
           files: |
@@ -23,12 +23,12 @@ jobs:
           since_last_remote_commit: false
       - name: Setup Python
         if: ${{ steps.changed-files.outputs.all_changed_files }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.10"
       - name: Setup Poetry
         if: ${{ steps.changed-files.outputs.all_changed_files }}
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install python dependencies
         if: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |

--- a/.github/workflows/run-secrets-detection.yml
+++ b/.github/workflows/run-secrets-detection.yml
@@ -7,13 +7,13 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.9"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install Python Dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/sync-contribution-base-branch-on-change.yml
+++ b/.github/workflows/sync-contribution-base-branch-on-change.yml
@@ -16,13 +16,13 @@ jobs:
     if: github.repository == 'demisto/content' && github.event.pull_request.head.repo.fork == true && contains(github.head_ref, 'xsoar-bot-contrib-ContributionTestPack') == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.9"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install Python Dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/sync-contribution-base-branch.yml
+++ b/.github/workflows/sync-contribution-base-branch.yml
@@ -13,13 +13,13 @@ jobs:
     if: github.repository == 'demisto/content'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.9"
       - name: Setup Poetry
-        uses: Gr1N/setup-poetry@v9
+        uses: Gr1N/setup-poetry@48b0f77c8c1b1b19cb962f0f00dff7b4be8f81ec # v9
       - name: Install Python Dependencies
         run: |
           poetry install --with github-actions

--- a/.github/workflows/update-demisto-sdk-version.yml
+++ b/.github/workflows/update-demisto-sdk-version.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
     - name: Install poetry
-      uses: Gr1N/setup-poetry@v8
+      uses: Gr1N/setup-poetry@15821dc8a61bc630db542ae4baf6a7c19a994844 # v8
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
         token: ${{ secrets.CONTENTBOT_GH_ADMIN_TOKEN }}
 
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
       with:
         python-version: '3.10'
         cache: 'poetry'


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions